### PR TITLE
update cortex-m-rt dependency to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ vcell = "0.1"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.3"
+version = "0.4"
 
 [features]
 rt = ["cortex-m-rt"]


### PR DESCRIPTION
Thank you for publishing this crate!

The `cortex-m-rt` dependency has a new release. [Motivation](https://users.rust-lang.org/t/cortex-m-rt-v0-4-0-now-you-can-link-arm-cortex-m-programs-using-lld/16751)

I'm going to follow up with [stm32f429-hal](https://github.com/astro/stm32f429-hal).